### PR TITLE
reflection't

### DIFF
--- a/src/main/resources/chat-utils.mixins.json
+++ b/src/main/resources/chat-utils.mixins.json
@@ -6,8 +6,9 @@
   "mixins": [
   ],
   "client": [
+    "CopyToClipboardMixin",
     "ReceiveMessageMixin",
-    "CopyToClipboardMixin"
+    "ReceiveMessageMixin$ChatHudAccessor"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
This is much cleaner and will avoid issues like
with Quilt switching to Hashed Mojang Mappings
from Intermediary in the future (since they plan
on remapping Intermediary mods to Hashed MojMap
at runtime, which reflection will misbehave with
unless you use the appropriate loader APIs to get,
field names, which wasn't the case here anyway:
https://fabricmc.net/wiki/tutorial:reflection).