### PR TITLE
Rewrite anti-spam.

### DIFF
--- a/src/main/java/io/github/hotlava03/chatutils/fileio/ChatStorage.java
+++ b/src/main/java/io/github/hotlava03/chatutils/fileio/ChatStorage.java
@@ -14,7 +14,7 @@ public class ChatStorage {
     private static ChatStorage instance;
     private final Gson gson = new Gson();
     private JsonObject object = new JsonObject();
-    private boolean blockingChatEvents = true;
+    private boolean blockingChatEvents = false;
 
     private ChatStorage() {
     }

--- a/src/main/java/io/github/hotlava03/chatutils/fileio/ChatUtilsConfig.java
+++ b/src/main/java/io/github/hotlava03/chatutils/fileio/ChatUtilsConfig.java
@@ -17,6 +17,7 @@ public class ChatUtilsConfig {
     public static final Value<Boolean> COPY_COLORS = new Value<>("copyColorsIfAny", false);
     public static final Value<Boolean> COPY_HEX_COLORS = new Value<>("copyHexColors", true);
     public static final Value<Boolean> ANTI_SPAM = new Value<>("antiSpam", true);
+    public static final Value<Integer> ANTI_SPAM_RANGE = new Value<>("antiSpamRange", 3);
     public static final Value<Boolean> TOOLTIP_ENABLED = new Value<>("tooltipEnabled", true);
     public static final Value<Boolean> ENABLED = new Value<>("enabled", true);
     public static final Value<Boolean> ENABLE_CHAT_PERSIST = new Value<>("enableChatPersist", true);
@@ -36,6 +37,7 @@ public class ChatUtilsConfig {
                     COPY_COLORS.read(root.get("copyColorsIfAny"), JsonElement::getAsBoolean);
                     COPY_HEX_COLORS.read(root.get("copyHexColors"), JsonElement::getAsBoolean);
                     ANTI_SPAM.read(root.get("antiSpam"), JsonElement::getAsBoolean);
+                    ANTI_SPAM_RANGE.read(root.get("antiSpamRange"), JsonElement::getAsInt);
                     TOOLTIP_ENABLED.read(root.get("tooltipEnabled"), JsonElement::getAsBoolean);
                     ENABLED.read(root.get("enabled"), JsonElement::getAsBoolean);
                     ENABLE_CHAT_PERSIST.read(root.get("enableChatPersist"), JsonElement::getAsBoolean);
@@ -61,6 +63,7 @@ public class ChatUtilsConfig {
                 chatUtils.addProperty(COPY_COLORS.name(), COPY_COLORS.value());
                 chatUtils.addProperty(COPY_HEX_COLORS.name, COPY_HEX_COLORS.value());
                 chatUtils.addProperty(ANTI_SPAM.name(), ANTI_SPAM.value());
+                chatUtils.addProperty(ANTI_SPAM_RANGE.name(), ANTI_SPAM_RANGE.value());
                 chatUtils.addProperty(TOOLTIP_ENABLED.name(), TOOLTIP_ENABLED.value());
                 chatUtils.addProperty(ENABLED.name(), ENABLED.value());
                 chatUtils.addProperty(ENABLE_CHAT_PERSIST.name(), ENABLE_CHAT_PERSIST.value());

--- a/src/main/java/io/github/hotlava03/chatutils/fileio/ChatUtilsConfig.java
+++ b/src/main/java/io/github/hotlava03/chatutils/fileio/ChatUtilsConfig.java
@@ -17,7 +17,7 @@ public class ChatUtilsConfig {
     public static final Value<Boolean> COPY_COLORS = new Value<>("copyColorsIfAny", false);
     public static final Value<Boolean> COPY_HEX_COLORS = new Value<>("copyHexColors", true);
     public static final Value<Boolean> ANTI_SPAM = new Value<>("antiSpam", true);
-    public static final Value<Integer> ANTI_SPAM_RANGE = new Value<>("antiSpamRange", 3);
+    public static final Value<Integer> ANTI_SPAM_RANGE = new Value<>("antiSpamRange", 16);
     public static final Value<Boolean> TOOLTIP_ENABLED = new Value<>("tooltipEnabled", true);
     public static final Value<Boolean> ENABLED = new Value<>("enabled", true);
     public static final Value<Boolean> ENABLE_CHAT_PERSIST = new Value<>("enableChatPersist", true);

--- a/src/main/java/io/github/hotlava03/chatutils/gui/ConfigGui.java
+++ b/src/main/java/io/github/hotlava03/chatutils/gui/ConfigGui.java
@@ -17,6 +17,7 @@ public class ConfigGui {
                 });
         ConfigCategory general = builder.getOrCreateCategory(Text.translatable("chat-utils.config_title"));
         addBooleanEntry(general, builder, ChatUtilsConfig.ANTI_SPAM);
+        addIntEntry(general, builder, ChatUtilsConfig.ANTI_SPAM_RANGE, 1, 99);
         addBooleanEntry(general, builder, ChatUtilsConfig.ENABLED);
         addBooleanEntry(general, builder, ChatUtilsConfig.TOOLTIP_ENABLED);
         addStringEntry(general, builder, ChatUtilsConfig.COPY_TO_CLIPBOARD_MESSAGE);
@@ -42,6 +43,16 @@ public class ConfigGui {
                                         ChatUtilsConfig.Value<Boolean> value) {
         category.addEntry(builder.entryBuilder()
                 .startBooleanToggle(Text.translatable("chat-utils.configs." + value.name() + ".label"), value.value())
+                .setDefaultValue(value.defaultValue())
+                .setTooltip(Text.translatable("chat-utils.configs." + value.name() + ".description"))
+                .setSaveConsumer(value::setValue)
+                .build());
+    }
+
+    private static void addIntEntry(ConfigCategory category, ConfigBuilder builder,
+                                        ChatUtilsConfig.Value<Integer> value, int min, int max) {
+        category.addEntry(builder.entryBuilder()
+                .startIntSlider(Text.translatable("chat-utils.configs." + value.name() + ".label"), value.value(), min, max)
                 .setDefaultValue(value.defaultValue())
                 .setTooltip(Text.translatable("chat-utils.configs." + value.name() + ".description"))
                 .setSaveConsumer(value::setValue)

--- a/src/main/java/io/github/hotlava03/chatutils/listeners/AntiSpamListener.java
+++ b/src/main/java/io/github/hotlava03/chatutils/listeners/AntiSpamListener.java
@@ -86,13 +86,6 @@ public class AntiSpamListener implements Consumer<ReceiveMessageEvent> {
 
             if (i + lineMatchCount >= i) {
                 history.subList(i, i + lineMatchCount + 1).clear();
-                /*if (address != null) {
-                    var storage = ChatStorage.getInstance();
-                    for (int j = i; j <= i + lineMatchCount; j++) {
-                        storage.removeChat(address, j);
-                    }
-                    storage.saveAsync();
-                }*/
             }
             lineMatchCount = 0;
         }

--- a/src/main/java/io/github/hotlava03/chatutils/listeners/AntiSpamListener.java
+++ b/src/main/java/io/github/hotlava03/chatutils/listeners/AntiSpamListener.java
@@ -26,12 +26,12 @@ public class AntiSpamListener implements Consumer<ReceiveMessageEvent> {
         var history = fullHistory.size() >= range ? fullHistory.subList(0, range) : fullHistory;
         if (history.isEmpty()) return;
 
-        int maxTextLength = MathHelper.floor(chat.getWidth() / chat.getChatScale());
+        var maxTextLength = MathHelper.floor(chat.getWidth() / chat.getChatScale());
         var splitLines = ChatMessages.breakRenderedChatMessageLines(
                 e.getText(), maxTextLength, client.textRenderer);
 
-        int spamCounter = 1;
-        int lineMatchCount = 0;
+        var spamCounter = 1;
+        var lineMatchCount = 0;
 
         for (int i = history.size() - 1; i >= 0; i--) {
             var previous = orderedTextToString(history.get(i).content());

--- a/src/main/java/io/github/hotlava03/chatutils/listeners/AntiSpamListener.java
+++ b/src/main/java/io/github/hotlava03/chatutils/listeners/AntiSpamListener.java
@@ -58,11 +58,11 @@ public class AntiSpamListener implements Consumer<ReceiveMessageEvent> {
                     if (appended.startsWith(" [x") && appended.endsWith("]")) {
                         var previousCounter = appended.substring(3, appended.length() - 1);
 
-                        if (isNumeric(previousCounter)) {
+                        try {
                             spamCounter += Integer.parseInt(previousCounter);
                             lineMatchCount++;
                             continue;
-                        }
+                        } catch (NumberFormatException ignored) {}
                     }
                 }
 

--- a/src/main/java/io/github/hotlava03/chatutils/listeners/AntiSpamListener.java
+++ b/src/main/java/io/github/hotlava03/chatutils/listeners/AntiSpamListener.java
@@ -19,6 +19,8 @@ public class AntiSpamListener implements Consumer<ReceiveMessageEvent> {
         if (ChatStorage.getInstance().isBlockingChatEvents()) return;
         var client = MinecraftClient.getInstance();
         var chat = client.inGameHud.getChatHud();
+        var serverInfo = client.getCurrentServerEntry();
+        var address = serverInfo != null ? serverInfo.address : null;
         var fullHistory = e.getLines();
         var range = ChatUtilsConfig.ANTI_SPAM_RANGE.value();
         var history = fullHistory.size() >= range ? fullHistory.subList(0, range) : fullHistory;
@@ -82,7 +84,16 @@ public class AntiSpamListener implements Consumer<ReceiveMessageEvent> {
                 }
             }
 
-            if (i + lineMatchCount >= i) history.subList(i, i + lineMatchCount + 1).clear();
+            if (i + lineMatchCount >= i) {
+                history.subList(i, i + lineMatchCount + 1).clear();
+                /*if (address != null) {
+                    var storage = ChatStorage.getInstance();
+                    for (int j = i; j <= i + lineMatchCount; j++) {
+                        storage.removeChat(address, j);
+                    }
+                    storage.saveAsync();
+                }*/
+            }
             lineMatchCount = 0;
         }
 

--- a/src/main/java/io/github/hotlava03/chatutils/listeners/AntiSpamListener.java
+++ b/src/main/java/io/github/hotlava03/chatutils/listeners/AntiSpamListener.java
@@ -1,34 +1,91 @@
 package io.github.hotlava03.chatutils.listeners;
 
-import io.github.hotlava03.chatutils.fileio.ChatStorage;
-import io.github.hotlava03.chatutils.fileio.ChatUtilsConfig;
 import io.github.hotlava03.chatutils.events.ReceiveMessageEvent;
-import io.github.hotlava03.chatutils.util.StringUtils;
-import net.minecraft.text.Text;
+import io.github.hotlava03.chatutils.fileio.ChatUtilsConfig;
+import io.github.hotlava03.chatutils.mixin.MessageHistoryAccessor;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.util.ChatMessages;
+import net.minecraft.util.math.MathHelper;
 
 import java.util.function.Consumer;
 
-public class AntiSpamListener implements Consumer<ReceiveMessageEvent> {
-    private Text lastMessage;
-    private int spamCounter = 1;
+import static io.github.hotlava03.chatutils.util.OrderedTextAdapter.orderedTextToString;
+import static io.github.hotlava03.chatutils.util.StringUtils.getDifference;
+import static io.github.hotlava03.chatutils.util.StringUtils.isNumeric;
 
+public class AntiSpamListener implements Consumer<ReceiveMessageEvent> {
     @Override
     public void accept(ReceiveMessageEvent e) {
-        if (ChatStorage.getInstance().isBlockingChatEvents()) return;
-        if (ChatUtilsConfig.ANTI_SPAM.value()) {
-            if (this.lastMessage == null) {
-                this.lastMessage = e.getText();
-                this.spamCounter = 1;
-                return;
+        var client = MinecraftClient.getInstance();
+        var chat = client.inGameHud.getChatHud();
+        var accessor = (MessageHistoryAccessor) chat;
+        var fullHistory = accessor.getVisibleMessages();
+        var range = ChatUtilsConfig.ANTI_SPAM_RANGE.value();
+        var history = fullHistory.size() >= range ? accessor.getVisibleMessages().subList(0, range) : fullHistory;
+        if (history.isEmpty()) return;
+
+        int maxTextLength = MathHelper.floor(chat.getWidth() / chat.getChatScale());
+        var splitLines = ChatMessages.breakRenderedChatMessageLines(
+                e.getText(), maxTextLength, client.textRenderer);
+
+        int spamCounter = 1;
+        int lineMatchCount = 0;
+
+        for (int i = history.size() - 1; i >= 0; i--) {
+            var previous = orderedTextToString(history.get(i).content());
+
+            if (lineMatchCount <= splitLines.size() - 1) {
+                String next = orderedTextToString(splitLines.get(lineMatchCount));
+
+                if (lineMatchCount < splitLines.size() - 1) {
+                    if (getDifference(previous, next) <= 0) lineMatchCount++;
+                    else lineMatchCount = 0;
+
+                    continue;
+                }
+
+                if (!previous.startsWith(next)) {
+                    lineMatchCount = 0;
+                    continue;
+                }
+
+                if (i > 0 && lineMatchCount == splitLines.size() - 1) {
+                    var appended = (previous + orderedTextToString(history.get(i - 1).content()))
+                            .substring(next.length());
+
+                    if (appended.startsWith(" [x") && appended.endsWith("]")) {
+                        var previousCounter = appended.substring(3, appended.length() - 1);
+
+                        if (isNumeric(previousCounter)) {
+                            spamCounter += Integer.parseInt(previousCounter);
+                            lineMatchCount++;
+                            continue;
+                        }
+                    }
+                }
+
+                if (previous.length() == next.length()) spamCounter++;
+                else {
+                    var appended = previous.substring(next.length());
+                    if (!appended.startsWith(" [x") || !appended.endsWith("]")) {
+                        lineMatchCount = 0;
+                        continue;
+                    }
+
+                    var previousCounter = appended.substring(3, appended.length() - 1);
+                    if (!isNumeric(previousCounter)) {
+                        lineMatchCount = 0;
+                        continue;
+                    }
+
+                    spamCounter += Integer.parseInt(previousCounter);
+                }
             }
-            if (StringUtils.getDifference(e.getText().getString(), this.lastMessage.getString()) <= 0) {
-                this.spamCounter++;
-                e.getTextAsMutable().append(StringUtils.translateAlternateColorCodes(" &8[&c" + this.spamCounter + "x&8]"));
-                e.getLines().remove(0);
-            } else {
-                this.lastMessage = e.getText();
-                this.spamCounter = 1;
-            }
+
+            if (i + lineMatchCount >= i) history.subList(i, i + lineMatchCount + 1).clear();
+            lineMatchCount = 0;
         }
+
+        if (spamCounter > 1) e.getTextAsMutable().append(" §8[§cx" + spamCounter + "§8]");
     }
 }

--- a/src/main/java/io/github/hotlava03/chatutils/listeners/AntiSpamListener.java
+++ b/src/main/java/io/github/hotlava03/chatutils/listeners/AntiSpamListener.java
@@ -3,7 +3,6 @@ package io.github.hotlava03.chatutils.listeners;
 import io.github.hotlava03.chatutils.events.ReceiveMessageEvent;
 import io.github.hotlava03.chatutils.fileio.ChatStorage;
 import io.github.hotlava03.chatutils.fileio.ChatUtilsConfig;
-import io.github.hotlava03.chatutils.mixin.MessageHistoryAccessor;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.util.ChatMessages;
 import net.minecraft.util.math.MathHelper;
@@ -20,10 +19,9 @@ public class AntiSpamListener implements Consumer<ReceiveMessageEvent> {
         if (ChatStorage.getInstance().isBlockingChatEvents()) return;
         var client = MinecraftClient.getInstance();
         var chat = client.inGameHud.getChatHud();
-        var accessor = (MessageHistoryAccessor) chat;
-        var fullHistory = accessor.getVisibleMessages();
+        var fullHistory = e.getLines();
         var range = ChatUtilsConfig.ANTI_SPAM_RANGE.value();
-        var history = fullHistory.size() >= range ? accessor.getVisibleMessages().subList(0, range) : fullHistory;
+        var history = fullHistory.size() >= range ? fullHistory.subList(0, range) : fullHistory;
         if (history.isEmpty()) return;
 
         int maxTextLength = MathHelper.floor(chat.getWidth() / chat.getChatScale());

--- a/src/main/java/io/github/hotlava03/chatutils/listeners/AntiSpamListener.java
+++ b/src/main/java/io/github/hotlava03/chatutils/listeners/AntiSpamListener.java
@@ -75,12 +75,12 @@ public class AntiSpamListener implements Consumer<ReceiveMessageEvent> {
                     }
 
                     var previousCounter = appended.substring(3, appended.length() - 1);
-                    if (!isNumeric(previousCounter)) {
+                    try {
+                        spamCounter += Integer.parseInt(previousCounter);
+                    } catch (NumberFormatException e) {
                         lineMatchCount = 0;
                         continue;
                     }
-
-                    spamCounter += Integer.parseInt(previousCounter);
                 }
             }
 

--- a/src/main/java/io/github/hotlava03/chatutils/listeners/AntiSpamListener.java
+++ b/src/main/java/io/github/hotlava03/chatutils/listeners/AntiSpamListener.java
@@ -1,6 +1,7 @@
 package io.github.hotlava03.chatutils.listeners;
 
 import io.github.hotlava03.chatutils.events.ReceiveMessageEvent;
+import io.github.hotlava03.chatutils.fileio.ChatStorage;
 import io.github.hotlava03.chatutils.fileio.ChatUtilsConfig;
 import io.github.hotlava03.chatutils.mixin.MessageHistoryAccessor;
 import net.minecraft.client.MinecraftClient;
@@ -16,6 +17,7 @@ import static io.github.hotlava03.chatutils.util.StringUtils.isNumeric;
 public class AntiSpamListener implements Consumer<ReceiveMessageEvent> {
     @Override
     public void accept(ReceiveMessageEvent e) {
+        if (ChatStorage.getInstance().isBlockingChatEvents()) return;
         var client = MinecraftClient.getInstance();
         var chat = client.inGameHud.getChatHud();
         var accessor = (MessageHistoryAccessor) chat;

--- a/src/main/java/io/github/hotlava03/chatutils/listeners/ChatPersistListener.java
+++ b/src/main/java/io/github/hotlava03/chatutils/listeners/ChatPersistListener.java
@@ -10,7 +10,7 @@ import java.util.function.Consumer;
 import java.util.regex.Pattern;
 
 public class ChatPersistListener implements Consumer<ReceiveMessageEvent> {
-    private static final String ANTI_SPAM_REGEX = " §8\\[§c\\dx§8]$";
+    private static final String ANTI_SPAM_REGEX = " §8\\[§cx\\d§8]$";
     private static final Pattern ANTI_SPAM_PATTERN = Pattern.compile(ANTI_SPAM_REGEX);
 
     @Override
@@ -26,7 +26,7 @@ public class ChatPersistListener implements Consumer<ReceiveMessageEvent> {
         var lines = storage.getStoredChatLines(address);
 
         if (!lines.isEmpty() && !storage.isBlockingChatEvents()) {
-            var last = lines.get(lines.size() - 1);
+            var last = Text.Serializer.fromJson(lines.get(lines.size() - 1)).getString();
             if (message.matches(".+" + ANTI_SPAM_REGEX)) {
                 var lastLine = this.removeAntiSpamIndicator(last);
                 if (StringUtils.getDifference(this.removeAntiSpamIndicator(message), lastLine) <= 0) {

--- a/src/main/java/io/github/hotlava03/chatutils/listeners/SendMessageListener.java
+++ b/src/main/java/io/github/hotlava03/chatutils/listeners/SendMessageListener.java
@@ -17,6 +17,8 @@ public class SendMessageListener implements Consumer<SendMessageEvent> {
         if (e.getLine().startsWith("/chatmacros ")) return;
 
         var storage = ChatStorage.getInstance();
+        var cmds = storage.getStoredCmdLines(address);
+        if (cmds.get(cmds.size() - 1).equals(e.getLine())) return;
         storage.pushCmd(e.getLine(), address);
         storage.saveAsync();
     }

--- a/src/main/java/io/github/hotlava03/chatutils/mixin/MessageHistoryAccessor.java
+++ b/src/main/java/io/github/hotlava03/chatutils/mixin/MessageHistoryAccessor.java
@@ -1,6 +1,7 @@
 package io.github.hotlava03.chatutils.mixin;
 
 import net.minecraft.client.gui.hud.ChatHud;
+import net.minecraft.client.gui.hud.ChatHudLine;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
 
@@ -10,4 +11,7 @@ import java.util.List;
 public interface MessageHistoryAccessor {
     @Accessor
     List<String> getMessageHistory();
+
+    @Accessor
+    List<ChatHudLine.Visible> getVisibleMessages();
 }

--- a/src/main/java/io/github/hotlava03/chatutils/mixin/ReceiveMessageMixin.java
+++ b/src/main/java/io/github/hotlava03/chatutils/mixin/ReceiveMessageMixin.java
@@ -1,27 +1,21 @@
 package io.github.hotlava03.chatutils.mixin;
 
 import io.github.hotlava03.chatutils.events.ReceiveMessageEvent;
+import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.hud.ChatHud;
-import net.minecraft.client.gui.hud.ChatHudLine;
 import net.minecraft.client.gui.hud.MessageIndicator;
 import net.minecraft.network.message.MessageSignatureData;
 import net.minecraft.text.*;
-import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import java.util.List;
-
 @Mixin(ChatHud.class)
 public class ReceiveMessageMixin {
-    @Shadow @Final private List<ChatHudLine.Visible> visibleMessages;
-
-    @Inject(method = "addMessage(Lnet/minecraft/text/Text;Lnet/minecraft/network/message/MessageSignatureData;ILnet/minecraft/client/gui/hud/MessageIndicator;Z)V",
-            at = @At("HEAD"))
-    public void addMessage(Text message, MessageSignatureData signature, int ticks, MessageIndicator indicator, boolean refresh, CallbackInfo ci) {
-        ReceiveMessageEvent.LISTENERS.fire(new ReceiveMessageEvent(ci, message, visibleMessages));
+    @Inject(method = "addMessage(Lnet/minecraft/text/Text;Lnet/minecraft/network/message/MessageSignatureData;Lnet/minecraft/client/gui/hud/MessageIndicator;)V", at = @At("HEAD"), cancellable = true)
+    public void addMessage(Text message, MessageSignatureData signature, MessageIndicator indicator, CallbackInfo ci) {
+        var accessor = (MessageHistoryAccessor) MinecraftClient.getInstance().inGameHud.getChatHud();
+        ReceiveMessageEvent.LISTENERS.fire(new ReceiveMessageEvent(ci, message, accessor.getVisibleMessages()));
     }
 }

--- a/src/main/java/io/github/hotlava03/chatutils/mixin/ReceiveMessageMixin.java
+++ b/src/main/java/io/github/hotlava03/chatutils/mixin/ReceiveMessageMixin.java
@@ -1,21 +1,26 @@
 package io.github.hotlava03.chatutils.mixin;
 
 import io.github.hotlava03.chatutils.events.ReceiveMessageEvent;
-import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.hud.ChatHud;
+import net.minecraft.client.gui.hud.ChatHudLine;
 import net.minecraft.client.gui.hud.MessageIndicator;
 import net.minecraft.network.message.MessageSignatureData;
 import net.minecraft.text.*;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import java.util.List;
+
 @Mixin(ChatHud.class)
 public class ReceiveMessageMixin {
+    @Shadow @Final private List<ChatHudLine.Visible> visibleMessages;
+
     @Inject(method = "addMessage(Lnet/minecraft/text/Text;Lnet/minecraft/network/message/MessageSignatureData;Lnet/minecraft/client/gui/hud/MessageIndicator;)V", at = @At("HEAD"), cancellable = true)
     public void addMessage(Text message, MessageSignatureData signature, MessageIndicator indicator, CallbackInfo ci) {
-        var accessor = (MessageHistoryAccessor) MinecraftClient.getInstance().inGameHud.getChatHud();
-        ReceiveMessageEvent.LISTENERS.fire(new ReceiveMessageEvent(ci, message, accessor.getVisibleMessages()));
+        ReceiveMessageEvent.LISTENERS.fire(new ReceiveMessageEvent(ci, message, visibleMessages));
     }
 }

--- a/src/main/java/io/github/hotlava03/chatutils/util/OrderedTextAdapter.java
+++ b/src/main/java/io/github/hotlava03/chatutils/util/OrderedTextAdapter.java
@@ -1,0 +1,28 @@
+package io.github.hotlava03.chatutils.util;
+
+import net.minecraft.text.CharacterVisitor;
+import net.minecraft.text.OrderedText;
+import net.minecraft.text.Style;
+
+public class OrderedTextAdapter {
+    public static String orderedTextToString(OrderedText text) {
+        var visitor = new TextVisitor();
+        text.accept(visitor);
+        return visitor.toString();
+    }
+
+    private static class TextVisitor implements CharacterVisitor {
+        StringBuilder sb = new StringBuilder();
+
+        @Override
+        public String toString() {
+            return sb.toString();
+        }
+
+        @Override
+        public boolean accept(int index, Style style, int codePoint) {
+            sb.appendCodePoint(codePoint);
+            return true;
+        }
+    }
+}

--- a/src/main/java/io/github/hotlava03/chatutils/util/StringUtils.java
+++ b/src/main/java/io/github/hotlava03/chatutils/util/StringUtils.java
@@ -38,4 +38,13 @@ public class StringUtils {
         if (useHexCodes) builder.hexColors();
         return builder.build().serialize(text.asComponent());
     }
+
+    public static boolean isNumeric(String str) {
+        try {
+            Integer.parseInt(str);
+            return true;
+        } catch (NumberFormatException e) {
+            return false;
+        }
+    }
 }

--- a/src/main/resources/assets/chat-utils/lang/en_us.json
+++ b/src/main/resources/assets/chat-utils/lang/en_us.json
@@ -10,6 +10,8 @@
   "chat-utils.configs.copyHexColors.description": "If disabled, copied colors will be downsampled to the closest legacy color code. Only works if \"copyColorsIfAny\" is enabled.",
   "chat-utils.configs.antiSpam.label": "Anti-Spam",
   "chat-utils.configs.antiSpam.description": "Collapse identical messages.",
+  "chat-utils.configs.antiSpamRange.label": "Anti-Spam Range",
+  "chat-utils.configs.antiSpamRange.description": "Chat Anti-Spam only triggers when messages are within this range from the latest message.",
   "chat-utils.configs.tooltipEnabled.label": "Enable Copy To Clipboard Tooltip",
   "chat-utils.configs.tooltipEnabled.description": "Click to disable any sort of tooltip when hovering over a message.",
   "chat-utils.configs.enabled.label": "Enable Copy To Clipboard",

--- a/src/main/resources/assets/chat-utils/lang/en_us.json
+++ b/src/main/resources/assets/chat-utils/lang/en_us.json
@@ -20,5 +20,5 @@
   "chat-utils.configs.enableChatPersist.description": "Saves chat from previous server sessions when logging back in later.",
   "chat-utils.configs.enableCommandPersist.label": "Enable Command History Persistence",
   "chat-utils.configs.enableCommandPersist.description": "Saves commands/sent chat from previous server sessions when logging back in later.",
-  "chat-utils.stored_messages": "[CHAT UTILS] &7Latest chat logs from &f%s"
+  "chat-utils.stored_messages": "[CHAT UTILS] &7Restored chat from &f%s"
 }

--- a/src/main/resources/assets/chat-utils/lang/pt_pt.json
+++ b/src/main/resources/assets/chat-utils/lang/pt_pt.json
@@ -10,6 +10,8 @@
   "chat-utils.configs.copyHexColors.description": "Se desativado, cores copiadas serão transformadas na cor \"legacy\" mais aproximada. Apenas funciona se \"copyColorsIfAny\" estiver ativado.",
   "chat-utils.configs.antiSpam.label": "Anti-Spam",
   "chat-utils.configs.antiSpam.description": "Colapsar mensagens idênticas.",
+  "chat-utils.configs.antiSpamRange.label": "Alcance do Anti-Spam",
+  "chat-utils.configs.antiSpamRange.description": "O sistema Anti-Spam apenas é chamado quando mensagens estão neste alcance da mensagem mais recente.",
   "chat-utils.configs.tooltipEnabled.label": "Mostrar Rótulo de Cópia",
   "chat-utils.configs.tooltipEnabled.description": "Mostrar qualquer tipo de rótulo ao passar o rato em cima de cada mensagem.",
   "chat-utils.configs.enabled.label": "Cópia Ativada",

--- a/src/main/resources/assets/chat-utils/lang/pt_pt.json
+++ b/src/main/resources/assets/chat-utils/lang/pt_pt.json
@@ -20,5 +20,5 @@
   "chat-utils.configs.enableChatPersist.description": "Guarda chat de sessões anteriores em servidores ao entrar nos mesmos novamente.",
   "chat-utils.configs.enableCommandPersist.label": "Persistência do histórico de comandos",
   "chat-utils.configs.enableCommandPersist.description": "Guarda comandos/chat enviado(s) de sessões anteriores em servidores ao entrar nos mesmos novamente.",
-  "chat-utils.stored_messages": "[CHAT UTILS] &7Logs de chat mais recentes de &f%s"
+  "chat-utils.stored_messages": "[CHAT UTILS] &7Chat restaurado de &f%s"
 }


### PR DESCRIPTION
- [x] Test with the event block check.
- [x] Look into compatibility with chat persistence.
- [x] Remove accessor in ChatHud mixin and go back to shadow accessing; don't use accessor in listener but direct access to event attribute. 
- [x] Don't allow command persistence entries to duplicate, like Minecraft does it.